### PR TITLE
refactor: move db initialisation to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "../styles/globals.css";
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import Navbar from "@/ui/layout/Navbar/Navbar";
+import DatabaseInitializer from "@/lib/db/DatabaseInitialiser";
 
 const APP_NAME = "Things We Do";
 const APP_DEFAULT_TITLE = "Things We Do";
@@ -52,6 +53,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en" dir="ltr">
       <head />
       <body>
+        <DatabaseInitializer />
         <main className="pb-24">{children}</main>
         <Navbar />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,4 @@
-"use client";
-
-import { useEffect } from "react";
-import rxdbInit from "@/lib/db/rxdbInit";
-
 export default function Home() {
-  useEffect(() => {
-    const init = async () => {
-      try {
-        await rxdbInit();
-      } catch (error) {
-        console.error("Database initialization error:", error);
-      }
-    };
-    init();
-  }, []);
   return (
     <>
       <h1 className="text-red-500">Things We Do Home</h1>

--- a/src/lib/db/DatabaseInitialiser.tsx
+++ b/src/lib/db/DatabaseInitialiser.tsx
@@ -8,9 +8,11 @@ export default function DatabaseInitializer() {
     const init = async () => {
       try {
         await rxdbInit();
-        console.log("Database initialized successfully!");
       } catch (error) {
-        console.error("Database initialization error:", error);
+        console.error(
+          "Database initialization error in DatabaseInitialiser:",
+          error
+        );
       }
     };
 

--- a/src/lib/db/DatabaseInitialiser.tsx
+++ b/src/lib/db/DatabaseInitialiser.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import rxdbInit from "./rxdbInit";
+
+export default function DatabaseInitializer() {
+  useEffect(() => {
+    const init = async () => {
+      try {
+        await rxdbInit();
+        console.log("Database initialized successfully!");
+      } catch (error) {
+        console.error("Database initialization error:", error);
+      }
+    };
+
+    init();
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
…y page

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

# What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Styling
- [ ] Build
- [ ] Chore

## Description

- Moved db initalisation logic to a server side component that is rendered in root layout
- this means that `page.tsx` (particularly in the root) can be a server component, making the app more performant and aligning with the Next.JS paradigm
- Because the DatabaseInitialiser is in the root layout, it will be called no matter what page the user navigates to

## Screenshots

_Please replace this line with any relevant images for UI changes._

## UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_

- [ ] Semantic HTML implemented?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?

_Please aim to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: tested on my machine and does not build a new feature
- [ ] I need help with writing tests

## Delete branch after merge?

- [x] Yes
- [ ] No

## What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmQwbjlpNHR2YmsxeGU0a2traWNnMm4zMW51OW5xcTV2bmxoZHlhbyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l0K4mbH4lKBhAPFU4/giphy.gif)
