### PR TITLE
Style/navbar toolkit highlight

### DIFF
--- a/__tests__/Navbarlinks.test.tsx
+++ b/__tests__/Navbarlinks.test.tsx
@@ -19,7 +19,7 @@ describe("NavbarLinks", () => {
     // Check if all link titles are rendered
     expect(screen.getByText("Home")).toBeInTheDocument();
     expect(screen.getByText("Moods")).toBeInTheDocument();
-    expect(screen.getByText("Toolkit")).toBeInTheDocument();
+
     expect(screen.getByText("Needs")).toBeInTheDocument();
     expect(screen.getByText("Insights")).toBeInTheDocument();
   });
@@ -47,8 +47,8 @@ describe("NavbarLinks", () => {
     const navContainer = container.firstChild;
 
     expect(navContainer).toHaveClass(
-      "grid",
-      "grid-cols-5",
+      "flex",
+      "justify-between",
       "items-center",
       "h-full",
       "w-11/12",

--- a/src/app/toolkit/components/floatingButton.tsx
+++ b/src/app/toolkit/components/floatingButton.tsx
@@ -8,7 +8,7 @@ export default function FloatingButton() {
     <Link href="/addTool">
       <Button
         label="Add a Tool"
-        className="fixed bottom-20 right-4 bg-blue-500 text-white shadow-lg"
+        className="fixed bottom-24 right-4 bg-twd-primary-purple text-white shadow-lg"
       />
     </Link>
   );

--- a/src/ui/shared/NavLink.tsx
+++ b/src/ui/shared/NavLink.tsx
@@ -27,9 +27,9 @@ export default function NavLink({
         `flex flex-col items-center justify-center w-14 h-14 text-gray-400 relative`,
         {
           "text-white": isActive,
+          "!bg-gray-200 !text-twd-primary-purple": isActive && isToolkit,
           "border-twd-primary-purple border-solid border-[3px] rounded-full p-10 bg-twd-navbar-background shadow-[0px_0px_8px_2px_rgba(137,63,252)] -translate-y-4":
             isToolkit,
-          "bg-gray-100 text-twd-primary-purple ": isActive && isToolkit,
         }
       )}
     >


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

# What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Styling
- [ ] Build
- [ ] Chore

## Description

- Fixed styles for navbar toolkit - now has light gray background when selected (unfortunately had to use !important in tailwind for this). @maxitect this fixed that missing `bg-gray-200` class that wouldn't apply yesterday.
- Changed colour of @JasonWarrenUK's `Add A Tool` button to be more consistent with overall design

## Screenshots

![Screenshot 2024-12-06 at 10 50 01](https://github.com/user-attachments/assets/e2c74269-88b4-48d6-961b-78fa04aeeb8b)
![Screenshot 2024-12-06 at 10 50 06](https://github.com/user-attachments/assets/41b159d8-7081-4f9b-96df-5eb9d371a519)


## UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_

- [ ] Semantic HTML implemented?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?

_Please aim to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Delete branch after merge?

- [x] Yes
- [ ] No

## What gif best describes this PR or how it makes you feel?

![alt_text](https://uploads.dailydot.com/2024/11/Screen-Shot-2024-11-06-at-5.17.40-PM.png?auto=compress&fm=png)
