### PR TITLE
Moods/fixes

### DIFF
--- a/__tests__/MoodsCube.test.tsx
+++ b/__tests__/MoodsCube.test.tsx
@@ -60,8 +60,8 @@ describe("Cube and SliderBox integration", () => {
       (d: any) => d.type === "scatter3d" && d.mode === "markers"
     );
 
-    expect(scatterData.x).toEqual([5]);
+    expect(scatterData.x).toEqual([7]);
     expect(scatterData.y).toEqual([7]); // Inverted: 10 - 3 = 7
-    expect(scatterData.z).toEqual([7]);
+    expect(scatterData.z).toEqual([5]);
   });
 });

--- a/__tests__/toolkitAdd.test.tsx
+++ b/__tests__/toolkitAdd.test.tsx
@@ -1,5 +1,11 @@
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
-import AddToolPage from "@/app/addTool/page";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import AddToolPage from "@/app/toolkit/add-tool/page";
 import { AddToolProvider } from "@/context/AddToolContext";
 import { validateUrl } from "@/lib/utils/validateUrl";
 import DatabaseManager from "@/lib/db/DatabaseManager";
@@ -25,8 +31,8 @@ jest.mock("@/lib/db/DatabaseManager", () => ({
     addToDb: jest.fn(),
     getFromDb: jest.fn(),
     initialiseDatabase: jest.fn(),
-    addCategories: jest.fn()
-  }
+    addCategories: jest.fn(),
+  },
 }));
 
 describe("AddToolInputs Component", () => {

--- a/src/app/moods/components/Cube.tsx
+++ b/src/app/moods/components/Cube.tsx
@@ -100,9 +100,9 @@ export function Cube() {
             <PlotlyChart
               data={[
                 {
-                  x: [neuroState.dopamine ?? 0],
+                  x: [neuroState.adrenaline ?? 0],
                   y: [10 - (Number(neuroState.serotonin) ?? 0)],
-                  z: [neuroState.adrenaline ?? 0],
+                  z: [neuroState.dopamine ?? 0],
                   type: "scatter3d",
                   mode: "markers",
                   marker: {

--- a/src/app/moods/page.tsx
+++ b/src/app/moods/page.tsx
@@ -17,7 +17,7 @@ export default function MoodsPage() {
     adrenaline: 1,
   });
 
-  const submitMood = (path: string) => {
+  const submitMood = () => {
     const { dopamine, serotonin, adrenaline } = neuroState;
 
     const submitObj = {
@@ -31,8 +31,6 @@ export default function MoodsPage() {
     };
 
     DatabaseManager.addToDb("mood_records", submitObj);
-
-    router.push(`/${path}`);
   };
 
   return (
@@ -47,14 +45,14 @@ export default function MoodsPage() {
         <SliderBox />
         <div className="flex justify-between w-10/12 max-w-xl m-auto">
           <Button
-            label="Save and Exit"
-            className="border-white border-2 border-solid"
-            onClick={() => submitMood("")}
+            label="Save"
+            className="mt-2 px-3 py-1 bg-twd-primary-purple text-white rounded"
+            onClick={() => submitMood()}
           />
           <Button
-            label="Continue to Toolkit"
-            className="bg-twd-primary-purple"
-            onClick={() => submitMood("toolkit")}
+            label="Go to Insights"
+            className="mt-2 px-3 py-1 bg-gray-700 text-white rounded"
+            onClick={() => router.push("/insights")}
           />
         </div>
       </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

# What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Styling
- [ ] Build
- [x] Chore

## Description

### Summary

This pull request enhances the 3D cube data visualization, improves navigation functionality, and refines styling and component usage across the application.

### Updates
- **Cube Visualization:**
  - Updated neurotransmitter axis values in `Cube.tsx` to reflect accurate data representation for the cube data visualization.
- **Moods Page Navigation:**
  - Rationalized buttons on the `Moods.page.tsx`:
    - Simplified options to either save a mood or navigate directly to the insights page for a streamlined user experience.
- **Tests:**
  - Updated expected slider/graph relationship in `MoodsCube.test.tsx`:
  - Updated import update missed out from PR #53 refactor in `toolkitAdd.test.tsx`. [NOTE: PLEASE RUN ALL TESTS BEFORE MAKIGN A PR TO ENSURE THEY ALL PASS]

These updates improve data accuracy, navigation, and usability while maintaining visual and functional consistency across the application.

## Screenshots

![Screen Shot 2024-12-06 at 14 53 00](https://github.com/user-attachments/assets/457612e3-85f1-4a7f-8ac5-57c7df65bb38)

## UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_

- [x] Semantic HTML implemented?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?

_Please aim to keep the code coverage percentage at 80% and above._

- [x] Yes
![image](https://github.com/user-attachments/assets/2c8d5814-a1ee-497d-b072-efe1408c61a6)
- [ ] No, and this is why:
- [ ] I need help with writing tests

## Delete branch after merge?

- [x] Yes
- [ ] No

## What gif best describes this PR or how it makes you feel?

![kideating](https://media.giphy.com/media/Y3NWfcC00m1Zp0lc2T/giphy.gif?cid=790b7611ta44h7mur4u40k3q3sk4wdw5kx3qz54d5r89d0z7&ep=v1_gifs_trending&rid=giphy.gif&ct=g)
