### PR TITLE
Feature: add graceful fallback alternatives for img and link in toolkitpage

### DIFF
--- a/src/app/toolkit/components/SortableItem.tsx
+++ b/src/app/toolkit/components/SortableItem.tsx
@@ -16,16 +16,6 @@ interface SortableItemProps {
   handleDelete: (id: string) => void;
 }
 
-// const isValidUrl = (url: string | undefined): boolean => {
-//   if (!url) return false;
-//   try {
-//     new URL(url);
-//     return true;
-//   } catch {
-//     return false;
-//   }
-// };
-
 const isValidUrl = (url: string | undefined): boolean => {
   if (!url) return false;
   try {

--- a/src/app/toolkit/components/SortableItem.tsx
+++ b/src/app/toolkit/components/SortableItem.tsx
@@ -16,10 +16,20 @@ interface SortableItemProps {
   handleDelete: (id: string) => void;
 }
 
+// const isValidUrl = (url: string | undefined): boolean => {
+//   if (!url) return false;
+//   try {
+//     new URL(url);
+//     return true;
+//   } catch {
+//     return false;
+//   }
+// };
+
 const isValidUrl = (url: string | undefined): boolean => {
   if (!url) return false;
   try {
-    new URL(url);
+    new URL(url, window.location.href);
     return true;
   } catch {
     return false;
@@ -65,17 +75,20 @@ export default function SortableItem({
           </div>
 
           {/* Second Row: Image, Link, and Delete Button */}
-          <div className="flex items-center justify-between mt-2 w-full">
-            {/* Display the image */}
-            {isValidUrl(item.imageUrl) ? (
-              <img
-                src={item.imageUrl}
-                alt={item.name}
-                className="h-10 w-10 object-cover rounded"
-              />
-            ) : (
-              <span className="text-gray-400">No Image</span>
-            )}
+        <div className="flex items-center justify-between mt-2 w-full">
+          {/* Display the image or reserve space */}
+          {isValidUrl(item.imageUrl) ? (
+            <img
+              src={item.imageUrl}
+              alt={item.name}
+              className="h-10 w-10 object-cover rounded"
+            />
+          ) : (
+            <div className="h-10 w-10"></div> // Reserve space when no image
+          )}
+
+          {/* Display the link or reserve space */}
+          {isValidUrl(item.infoUrl) ? (
             <a
               href={item.infoUrl}
               target="_blank"
@@ -84,6 +97,11 @@ export default function SortableItem({
             >
               Go to resource
             </a>
+            ) : (
+              <div className="w-24"></div> // Reserve space for the link (adjust width as needed)
+            )}
+
+            {/* Delete button */}
             <button
               onClick={(e) => {
                 e.stopPropagation();


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

# What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Styling
- [ ] Build
- [ ] Chore

## Description

- Add graceful fallback options for missing images and links on the Toolkit page to ensure the UI remains consistent and user-friendly.

## Screenshots

<img width="372" alt="Screenshot 2024-12-10 at 22 05 39" src="https://github.com/user-attachments/assets/ea821a7b-b401-4cef-84a4-4feff56730d9">

## UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_

- [ ] Semantic HTML implemented?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?

_Please aim to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: don't need
- [ ] I need help with writing tests

## Delete branch after merge?

- [x] Yes
- [ ] No

## What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOG5wdDgyMzZqZjl3aDNiOGVkZnprN3VpbnVvZjZsZG1xYjZtMGJpMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/26u4lOMA8JKSnL9Uk/giphy.gif)
