### PR TITLE
Bugfix/db seed

### DIFF
--- a/src/lib/db/DatabaseManager.ts
+++ b/src/lib/db/DatabaseManager.ts
@@ -48,7 +48,7 @@ class DatabaseManager {
       "needs",
       "next_actions",
     ];
-    
+
     const existingCollections = Object.keys(dbInstance.collections);
 
     for (const collection of requiredCollections) {
@@ -76,15 +76,20 @@ class DatabaseManager {
   }
 
   private async seedDatabase() {
-    try {
-      await this.seed("mood_records", generateMoodRecords("dev"));
-      await this.seed("categories", categories);
-      await this.seed("toolkit_items", toolkit);
-      await this.seed("needs_categories", needsCategories);
-      await this.seed("needs", needs);
-      await this.seed("next_actions", nextActions);
-    } catch (error) {
-      console.error("Error during database seeding:", error);
+    if (
+      dbInstance &&
+      (await dbInstance.collections["needs"].find().exec()).length === 0
+    ) {
+      try {
+        await this.seed("mood_records", generateMoodRecords("dev"));
+        await this.seed("categories", categories);
+        await this.seed("toolkit_items", toolkit);
+        await this.seed("needs_categories", needsCategories);
+        await this.seed("needs", needs);
+        await this.seed("next_actions", nextActions);
+      } catch (error) {
+        console.error("Error during database seeding:", error);
+      }
     }
   }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

# What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Styling
- [ ] Build
- [ ] Chore

## Description

Fix database seeding bug when all toolkits are deleted, it is reseeded. We now use the needs collection to determine if the database has been seeded on initialisation already and avoid reseeding if any other collection becomes empty. This is the case because the user cannot add or delete needs, only update and so the collection should always contain the seed documents from initialisation.

## Screenshots

_Please replace this line with any relevant images for UI changes._

## UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_

- [ ] Semantic HTML implemented?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?

_Please aim to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: all tests pass after fix
- [ ] I need help with writing tests

## Delete branch after merge?

- [x] Yes
- [ ] No

## What gif best describes this PR or how it makes you feel?

![squashbug](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExanBuejh1Y21xdzJ0bjJ2YzFwZjhmMGEzNTczenY4bzZkaXV1cDI5cyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/ZbZXVdfoBxJuLk2yvH/giphy.gif)
